### PR TITLE
Fix unassign logic

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -912,12 +912,15 @@ class IssuesMixin(
                         logger.warning(f"Invalid attachments value: {value}")
 
                 elif key == "assignee":
-                    # Handle assignee updates
-                    try:
-                        account_id = self._get_account_id(value)
-                        self._add_assignee_to_fields(update_fields, account_id)
-                    except ValueError as e:
-                        logger.warning(f"Could not update assignee: {str(e)}")
+                    # Handle assignee updates, allow unassignment with None or empty string
+                    if value is None or value == "":
+                        update_fields["assignee"] = None
+                    else:
+                        try:
+                            account_id = self._get_account_id(value)
+                            self._add_assignee_to_fields(update_fields, account_id)
+                        except ValueError as e:
+                            logger.warning(f"Could not update assignee: {str(e)}")
                 else:
                     # Process regular fields using _process_additional_fields
                     # Create a temporary dict with just this field

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -690,6 +690,30 @@ class TestIssuesMixin:
         # Call the method with status in kwargs instead of fields
         issues_mixin.update_issue(issue_key="TEST-123", status="In Progress")
 
+    def test_update_issue_unassign(self, issues_mixin: IssuesMixin):
+        """Test unassigning an issue."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.update_issue(issue_key="TEST-123", assignee=None)
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123", update={"fields": {"assignee": None}}
+        )
+        assert not issues_mixin._get_account_id.called
+        assert document.key == "TEST-123"
+
     def test_delete_issue(self, issues_mixin: IssuesMixin):
         """Test deleting an issue."""
         # Call the method


### PR DESCRIPTION
## Summary
- support unassigning issues by handling `None` or empty assignee
- add unit test for unassigning an issue

## Testing
- `pre-commit run --all-files`
- `uv run pytest` *(fails: tests/test_real_api_validation.py: 32 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685327bb3260832281c636903ea6a80a